### PR TITLE
Fixed Gophish workdir to resolve v.0.5 build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ ca-certificates \
 wget && \
 apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-WORKDIR /opt
+WORKDIR /opt/gophish-v0.5.0-linux-64bit
 RUN wget -nv https://github.com/gophish/gophish/releases/download/v0.5.0/gophish-v0.5.0-linux-64bit.zip && \
 unzip gophish-v0.5.0-linux-64bit.zip && \
 rm -f gophish-v0.5.0-linux-64bit.zip
 
-WORKDIR /opt/gophish-v0.5.0-linux-64bit
 RUN sed -i "s|127.0.0.1|0.0.0.0|g" config.json && \
 chmod +x gophish
 


### PR DESCRIPTION
The 0.5 zip file does not create the `gophish-v0.5.0-linux-64bit` directory automatically while unpacking. This causes the Dockerfile build to fail as it can't find the `config.json` in the empty `/opt/gophish-v0.5.0-linux-64bit` directory:

```
$ docker build .
Sending build context to Docker daemon  148.5kB
Step 1/9 : FROM debian:jessie
 ---> ce40fb3adcc6
Step 2/9 : MAINTAINER Matteo Guglielmetti <matteo.guglielmetti@hotmail.it>
 ---> Using cache
 ---> bf2e445d735c
Step 3/9 : RUN apt-get update && apt-get install --no-install-recommends -y unzip ca-certificates wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ---> Using cache
 ---> f79a2792fb9a
Step 4/9 : WORKDIR /opt
 ---> Using cache
 ---> dcb5f1556389
Step 5/9 : RUN wget -nv https://github.com/gophish/gophish/releases/download/v0.5.0/gophish-v0.5.0-linux-64bit.zip && unzip gophish-v0.5.0-linux-64bit.zip && rm -f gophish-v0.5.0-linux-64bit.zip
 ---> Using cache
 ---> 6a4e00fbaa6d
Step 6/9 : WORKDIR /opt/gophish-v0.5.0-linux-64bit
 ---> Using cache
 ---> a19b63eb88f0
Step 7/9 : RUN sed -i "s|127.0.0.1|0.0.0.0|g" config.json && chmod +x gophish
 ---> Running in 9afcb846cb0b
sed: can't read config.json: No such file or directory
The command '/bin/sh -c sed -i "s|127.0.0.1|0.0.0.0|g" config.json && chmod +x gophish' returned a non-zero code: 2
```
This patch fixes the error by using `/opt/gophish-v0.5.0-linux-64bit` as a workdir and unpacking the zip from there.